### PR TITLE
Google Error Prone and JMH Generator

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,6 +24,7 @@ _Existing annotation processors for different purposes_
 * http://docs.jboss.org/hibernate/stable/validator/reference/en-US/html_single/#validator-annotation-processor[Hibernate Validator annotation processor] - Compile-time checking of Bean Validation constraints.
 * https://docs.jboss.org/hibernate/orm/current/topical/html_single/metamodelgen/MetamodelGenerator.html[JPA Static Metamodel Generator] - Creates JPA 2 static metamodel classes.
 * https://immutables.github.io/[Immutables] - Java annotation processors to generate simple, safe and consistent value objects.
+* https://github.com/openjdk/jmh[JMH Generator] - Generates Java Microbenchmark Harness (JMH) benchmarks.
 * http://mapstruct.org/[MapStruct] - Compile-time generator for type-safe bean-to-bean mapping code.
 * https://micronaut.io[Micronaut] - A modern full-stack framework for building modular, easily testable microservice and serverless applications.
 * https://github.com/sundrio/sundrio[Sundrio] - A collection of apt-based code generating tools, including advanced builder generator, dsl generator, velocity transformer and etc.

--- a/README.adoc
+++ b/README.adoc
@@ -19,6 +19,7 @@ _Existing annotation processors for different purposes_
 * https://github.com/DominoKit/domino-rest[domino-rest] - Generates rest clients from JaxRs compatible interfaces.
 * https://github.com/misberner/duzzt[Duzzt] - Duzzt - Annotation-based Embedded DSL Generator for Java.
 * https://github.com/google/auto[Google Auto] - A collection of source code generators for Java.
+* https://github.com/google/error-prone[Google Error Prone] - A static analysis tool for Java that catches common programming mistakes at compile-time.
 * https://github.com/LachlanMcKee/gsonpath[Gson Path] - A Java annotation processor library which generates gson type adapters using basic JsonPath style annotations.
 * http://docs.jboss.org/hibernate/stable/validator/reference/en-US/html_single/#validator-annotation-processor[Hibernate Validator annotation processor] - Compile-time checking of Bean Validation constraints.
 * https://docs.jboss.org/hibernate/orm/current/topical/html_single/metamodelgen/MetamodelGenerator.html[JPA Static Metamodel Generator] - Creates JPA 2 static metamodel classes.


### PR DESCRIPTION
Add two more annotation processing tools that I found useful:

* [Google Error Prone](https://github.com/google/error-prone) - A static analysis tool for Java that catches common programming mistakes at compile-time.

  ```
  com.google.errorprone:error_prone_core:2.4.0
  ```

* [JMH Generator](https://github.com/openjdk/jmh) - Generates Java Microbenchmark Harness (JMH) benchmarks. Actually I didn't find much information about this generator. I only found some brief information from the JMH GitHub project https://github.com/openjdk/jmh and the latest POM file here: https://github.com/openjdk/jmh/blob/1.26/jmh-generator-annprocess/pom.xml.

  ```
  org.openjdk.jmh:jmh-generator-annprocess:1.26
  ```