### PR TITLE
Include ascopes/java-compiler-testing in tools list

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,6 +54,7 @@ _Useful tools and libraries for implementing annotation processors_
 * https://github.com/toolisticon/aptk[APTK] - A toolbox that helps you to build annotation processors in a more efficient way.
 * https://github.com/avaje/avaje-prisms[Avaje Prisms] - A JDK 11 fork of Hickory with some minor enhancements.
 * https://github.com/google/compile-testing[Compile Testing] - Testing tools for javac and annotation processors.
+* https://github.com/ascopes/java-compiler-testing[Java Compiler Testing] - Library for integration testing annotation processors against javac. Supports testing packages and JPMS modules, uses in-memory file systems, and includes integrations with Junit5 and AssertJ.
 * https://github.com/toolisticon/cute[CUTE] - Testing tools for javac and annotation processors. Allows unit and black box testing.
 * https://github.com/Pante/elementary[Elementary] - A suite of JUnit 5 extensions that provides a real annotation processing environment during testing
 * https://github.com/square/javapoet[JavaPoet] - A Java API for generating .java source files.


### PR DESCRIPTION
I have just released v1.0.0 of https://github.com/ascopes/java-compiler-testing.

I was wondering if it would be possible to include it in this list (part of #24).

Hopefully this will be useful to annotation processor developers, as it aims to address some of the issues and limitations with other testing libraries that exist already.

Features to note that may make this useful to include on the list:

- Support for Java 11 through Java 21 EA
- Provides Junit5 integration
- Provides AssertJ-assertions
- Can detect the testing classpath and module path automatically.
- Fluent API
- Uses in-memory RAM disks, but can also support using real file system paths. Aims to keep tests fast, immutable, and reproducible.
- All builds I make have steps that validate that they are compatible with existing AP libraries, including avaje, ErrorProne, Lombok, Spring and Spring Boot APs, Micronaut, and some of the Google AP libraries.